### PR TITLE
Defaults to include all packages in source directories

### DIFF
--- a/src/docstring_checker/core.clj
+++ b/src/docstring_checker/core.clj
@@ -6,9 +6,9 @@
 
 (defn- should-check-namespace? [{:keys [include exclude]} nsname]
   (and nsname
-       (every? (fn [inclusion-pattern]
-                 (re-find inclusion-pattern nsname))
-               include)
+       (some (fn [inclusion-pattern]
+               (re-find inclusion-pattern nsname))
+             include)
        (every? (fn [exclusion-pattern]
                  (not (re-find exclusion-pattern nsname)))
                exclude)))

--- a/src/leiningen/docstring_checker.clj
+++ b/src/leiningen/docstring_checker.clj
@@ -9,7 +9,7 @@
             version))
         plugins))
 
-(defn get-packages [paths]
+(defn- get-packages [paths]
   (map #(re-pattern (str "^" (name %)))
        (b/namespaces-on-classpath :classpath
                                   (map io/file paths))))

--- a/src/leiningen/docstring_checker.clj
+++ b/src/leiningen/docstring_checker.clj
@@ -1,11 +1,18 @@
 (ns leiningen.docstring-checker
-  (:require [leiningen.core.eval :as lein]))
+  (:require [leiningen.core.eval :as lein]
+            [leiningen.compile :as lein-compile]
+            [bultitude.core :as b]))
 
 (defn- docstring-checker-version [{:keys [plugins]}]
   (some (fn [[plugin-name version]]
           (when (= plugin-name 'docstring-checker/docstring-checker)
             version))
         plugins))
+
+(defn get-packages [paths]
+  (map #(re-pattern (str "^" (name %)))
+       (b/namespaces-on-classpath :classpath
+                                  (map clojure.java.io/file paths))))
 
 (defn docstring-checker
   "Linter that checks all public vars in a Leiningen project have docstrings."
@@ -15,4 +22,7 @@
    (update-in project [:dependencies] conj ['docstring-checker (docstring-checker-version project)])
    `(do
       (require 'docstring-checker.core)
-      (docstring-checker.core/check-docstrings ~(:docstring-checker project)))))
+      (if ~(:docstring-checker project)
+        (docstring-checker.core/check-docstrings ~(:docstring-checker project))
+        (docstring-checker.core/check-docstrings {:include (vector ~@(get-packages (:source-paths project)))
+                                                  :exclude []})))))

--- a/src/leiningen/docstring_checker.clj
+++ b/src/leiningen/docstring_checker.clj
@@ -1,7 +1,7 @@
 (ns leiningen.docstring-checker
-  (:require [leiningen.core.eval :as lein]
-            [leiningen.compile :as lein-compile]
-            [bultitude.core :as b]))
+  (:require [bultitude.core :as b]
+            [clojure.java.io :as io]
+            [leiningen.core.eval :as lein]))
 
 (defn- docstring-checker-version [{:keys [plugins]}]
   (some (fn [[plugin-name version]]
@@ -12,7 +12,7 @@
 (defn get-packages [paths]
   (map #(re-pattern (str "^" (name %)))
        (b/namespaces-on-classpath :classpath
-                                  (map clojure.java.io/file paths))))
+                                  (map io/file paths))))
 
 (defn docstring-checker
   "Linter that checks all public vars in a Leiningen project have docstrings."


### PR DESCRIPTION
Ok, here's my first pass. I haven't checked it with complicated `:source-paths` variables yet, and I think I might have fixed a bug where nothing was being included unless it matched everything?

This is for issue #1, and *please* be brutal as I just kicked this out in a few hours and my macros are a little rusty.