### PR TITLE
Bump dependency versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "3-Clause BSD"
             :url "https://github.com/camsaul/lein-docstring-checker/blob/master/LICENSE.txt"}
   :eval-in-leiningen true
-  :dependencies [[org.clojure/java.classpath "0.2.3"]
-                 [org.clojure/tools.namespace "0.2.10"]]
+  :dependencies [[org.clojure/java.classpath "0.3.0"]
+                 [org.clojure/tools.namespace "0.2.11"]]
   :deploy-repositories [["clojars" {:sign-releases false}]])


### PR DESCRIPTION
Specifically the upgrade of `java.classpath` from `0.2.3` to `0.3.0`
will fix issues on JDK 9+.