### PR TITLE
Ignore proxy classes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject docstring-checker "1.0.2"
+(defproject docstring-checker "1.0.3-SNAPSHOT"
   :description "Linter that checks that public vars in your project all have docstrings."
   :url "https://github.com/camsaul/lein-docstring-checker"
   :license {:name "3-Clause BSD"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+lein install
+
 cd test-projects
 
 echo "Checking project 'good'..."

--- a/src/docstring_checker/core.clj
+++ b/src/docstring_checker/core.clj
@@ -1,8 +1,9 @@
 (ns docstring-checker.core
-  (:require [clojure.java.classpath :as classpath]
-            [clojure.pprint :as pprint]
-            (clojure.tools.namespace [find :as ns-find]
-                                     [file :as ns-file])))
+  (:require [clojure
+             [pprint :as pprint]
+             [string :as str]]
+            [clojure.java.classpath :as classpath]
+            [clojure.tools.namespace.find :as ns-find]))
 
 (defn- should-check-namespace?
   "Should we check the namespace with `nsname` for docstrings based on the `:include`/`:exclude` patterns?"
@@ -15,6 +16,15 @@
                  (not (re-find exclusion-pattern nsname)))
                exclude)))
 
+(defn- proxy?
+  "When using a Clojure `proxy` it creates a public var that uses the Java class naming conventions (i.e. `_` instead
+  of `-`) that is public and will cause the `things-that-need-dox` to be tripped with no way to attach documentation
+  to it. This function examines `symb` to see if it is from a generate proxy."
+  [ns-symb symb]
+  (let [ns-str   (str/replace (str ns-symb) \- \_)
+        symb-str (str symb)]
+    (.startsWith symb-str (str ns-str ".proxy$"))))
+
 (defn- things-that-need-dox
   "Return a sorted sequence of public vars that need documentation in namespaces that should be checked."
   [options]
@@ -23,7 +33,8 @@
               :when       (should-check-namespace? options (str ns-symb))
               [symb varr] (do (require ns-symb)
                               (ns-publics ns-symb))
-              :when       (not (:doc (meta varr)))]
+              :when       (and (not (:doc (meta varr)))
+                               (not (proxy? ns-symb symb)))]
           (symbol (str (ns-name ns-symb) "/" symb)))))
 
 (defn check-docstrings

--- a/test-projects/bad-with-patterns/project.clj
+++ b/test-projects/bad-with-patterns/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]]
-  :plugins [[docstring-checker "LATEST"]]
+  :plugins [[docstring-checker "[1.0.0,)"]]
   :docstring-checker {:include [#"^bad-with-patterns"]
                       :exclude []})

--- a/test-projects/bad/project.clj
+++ b/test-projects/bad/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]]
-  :plugins [[docstring-checker "LATEST"]])
+  :plugins [[docstring-checker "[1.0.0,)"]])

--- a/test-projects/good-with-patterns/project.clj
+++ b/test-projects/good-with-patterns/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]]
-  :plugins [[docstring-checker "LATEST"]]
+  :plugins [[docstring-checker "[1.0.0,)"]]
   :docstring-checker {:include [#"^good-with-patterns"]
                       :exclude [#"test"]})

--- a/test-projects/good/project.clj
+++ b/test-projects/good/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]]
-  :plugins [[docstring-checker "LATEST"]])
+  :plugins [[docstring-checker "[1.0.0,)"]])

--- a/test-projects/good/src/good/core.clj
+++ b/test-projects/good/src/good/core.clj
@@ -4,3 +4,10 @@
   "I'm ok, because I have a docstring."
   [x]
   (println x "Hello, World!"))
+
+(defn create-a-proxy
+  "A docstring here"
+  []
+  ;; This generates a proxy class which is a public var but should be ignored
+  (proxy [java.lang.Object] []
+    (toString [] "I'm an object")))


### PR DESCRIPTION
When using `proxy` in Clojure, it will create a new public var that is
not a `def` that doesn't have docs without an easy way to add it. It
would make more sense to doc the `def`/`defn` form that creates or
binds the `proxy` anyway. This commit adds a function to determine if
the var is a proxy and ignores it.